### PR TITLE
Add wp-ses to plugins

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -128,6 +128,7 @@ offload:
 plugins:
   - amazon-s3-and-cloudfront
   - amazon-s3-and-cloudfront-tweaks
+  - wp-ses
 
 hooks:
   pre-install:


### PR DESCRIPTION
the plugin wp-ses is part of the base image and therefore should be activated