### PR TITLE
use CronJob apiVersion batch/v1 in K8s v1.21+

### DIFF
--- a/templates/cron-job.yaml
+++ b/templates/cron-job.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: batch/v1
+{{- else -}}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ include "wordpress.fullname" . }}-cron


### PR DESCRIPTION
We got deprecation notice in clusters running K8s v1.21.5:

`batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob`